### PR TITLE
adding create project to role

### DIFF
--- a/android-sdk/tasks/main.yml
+++ b/android-sdk/tasks/main.yml
@@ -10,6 +10,11 @@
   set_fact: config_file_dir="/opt/rhmap/{{ rhmap_version }}/templates/buildfarm"
   when: config_file_dir is not defined
 
+- name: "Create project"
+  command: "oc new-project {{ project_name }}"
+  register: create_project_result
+  failed_when: create_project_result.stderr and create_project_result.stderr != '' and 'already_exists' not in create_project_result.stderr
+  changed_when: create_project_result.rc == 0 or (create_project_result == 1 and 'created' in create_project_result.stdout)
 
 -
   name: "Deploy the Android SDK image"


### PR DESCRIPTION
**What**
Adding a create project task to the role. 
This task will only complete if the user does not already have a project created using the default {{ project_name }}

**Why**
As this is a dependency of a playbook the project may already be created. If it is not however it should be created.

@aliok ping for review